### PR TITLE
Configurable BAM tag names for barcodes and barcode qualities

### DIFF
--- a/src/deML.cpp
+++ b/src/deML.cpp
@@ -922,6 +922,9 @@ int main (int argc, char *argv[]) {
 			      "\t\t"+"-i"+","+"--index"+"\t[index]"+"\t\t\t"+"File describing index sequences used"+"\n"+
 			      "\t\t"+"-o"+","+"--outfile"+"\t[outfile]"+"\t\t"+"Specify output file"+"\n\n"+
 
+			      "\t"+"BAM input options:"+"\n"+
+			      "\t\t"+"--bamtags"+"\t[Idx1Seq],[Idx1Qual],[Idx2Seq],[Idx2Qual]"+"\t"+"BAM Tags containing barcodes\n"+
+
 			      "\t"+"Fastq input/output (optional):"+"\n"+
 			      "\t\t"+"You can specify fastq as input/output, in which case the -o option will be"+"\n"+
 			      "\t\t"+"treated as an output prefix"+"\n"+
@@ -986,6 +989,26 @@ int main (int argc, char *argv[]) {
 	    reversefq = string(argv[i+1]);
 	    useFastq=true;
 	    lastIndexArgc = argc;
+	    i++;
+	    continue;
+	}
+
+	if(strcmp(argv[i],"--bamtags") == 0 ){
+	    istringstream iss(argv[i+1]);
+	    string tok;
+	    int p=0;
+	    while(getline(iss, tok, ',')) {
+	        switch (p) {
+	            case 0: tagIndex1Seq = tok; break;
+	            case 1: tagIndex1Qual = tok; break;
+	            case 2: tagIndex2Seq = tok; break;
+	            case 3: tagIndex2Qual = tok; break;
+	            default:
+	                cerr<<"too many commas in "<<argv[i+1]<<endl;
+	                exit(1);
+	        }
+	        ++p;
+	    }
 	    i++;
 	    continue;
 	}


### PR DESCRIPTION
It seems that BAM file with barcodes and qualities stored in the fields BC and QT are quite common, especially for data coming from Illumina MiSeq instruments. These files (at least the ones I'm receiving from the sequencing facility) also contain the barcode tags only on read 1.

I've modified deML to deal with this case. The BAM tag names can now be specified on the command line, and these tags missing on read2 is no longer an error.