### PR TITLE
actual index2 reported for conflicts for index2

### DIFF
--- a/src/RGAssign.cpp
+++ b/src/RGAssign.cpp
@@ -337,7 +337,7 @@ map<string,string>  readIndexFile(string filename,int mismatchesTrie,bool _shift
 	    }
 
 	    if(toPrint.length() > 0){
-		cerr<<values.indices1[i]<<" from "<<values.names[i]<<" causes a conflict with "<<toPrint<<endl;
+		cerr<<values.indices2[i]<<" from "<<values.names[i]<<" causes a conflict with "<<toPrint<<endl;
 	    }
 	}
 


### PR DESCRIPTION
G'day @grenaud 

Used deML for the first time, and noticed that while correctly identifying index2 conflicts, it reported the sequence for index1.
I changed RGAssign.cpp accordingly.

Best,

Josh